### PR TITLE
Updated server instance regex

### DIFF
--- a/src/Phpforce/SoapClient/Result/LoginResult.php
+++ b/src/Phpforce/SoapClient/Result/LoginResult.php
@@ -83,7 +83,7 @@ class LoginResult
         }
 
         $match = preg_match(
-            '/https:\/\/(?<instance>[^-\.]+)/',
+            '/https:\/\/(?<instance>.+).salesforce.com/',
             $this->serverUrl,
             $matches
         );


### PR DESCRIPTION
When an organization is configured with a custom domain name, the URL matches customname.my.salesforce.com (note the "my" injected into the name). I've updated the regex so that it matches the standard xxx.salesforce.com and xxx.my.salesforce.com variants of the servername.
