### PR TITLE
Fixed variable scoping issue which can lead to out of memory error.

### DIFF
--- a/src/Phpforce/SoapClient/Soap/SoapClient.php
+++ b/src/Phpforce/SoapClient/Soap/SoapClient.php
@@ -26,6 +26,7 @@ class SoapClient extends \SoapClient
 
             $soapTypes = $this->__getTypes();
             foreach ($soapTypes as $soapType) {
+                $properties = array();
                 $lines = explode("\n", $soapType);
                 if (!preg_match('/struct (.*) {/', $lines[0], $matches)) {
                     continue;


### PR DESCRIPTION
The `$properties` variable I'm assuming was expected to go out of scope, however it does not. Each iteration through the SOAP types appends more elements to the `$properties` array without clearing the data from the previous iteration, leading to massive memory consumption and Out of Memory errors in some cases. I added an explicit reassignment to the `$properties` variable.

In my specific case, this consumed 171MB, and has been reduced to 2MB.
