### PR TITLE
 Allow passing an array of user-specified options to SoapClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Use the client to query and manipulate your organisation’s Salesforce data. Fi
 
 ```php
 $builder = new \Phpforce\SoapClient\ClientBuilder(
-  '/path/to/your/salesforce/wsdl/sandbox.enterprise.wsdl.xml'
+  '/path/to/your/salesforce/wsdl/sandbox.enterprise.wsdl.xml',
   'username',
   'password',
   'security_token'
@@ -119,7 +119,7 @@ $log = new \Monolog\Logger('name');
 $log->pushHandler(new \Monolog\Handler\StreamHandler('path/to/your.log'));
 
 $builder = new \Phpforce\SoapClient\ClientBuilder(
-  '/path/to/your/salesforce/wsdl/sandbox.enterprise.wsdl.xml'
+  '/path/to/your/salesforce/wsdl/sandbox.enterprise.wsdl.xml',
   'username',
   'password',
   'security_token'

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $client = $builder->build();
 ### SOQL queries
 
 ```php
-$result = $client->query('select Name, SystemModstamp from Account limit 5');
+$results = $client->query('select Name, SystemModstamp from Account limit 5');
 ```
 
 This will fetch five accounts from Salesforce and return them as a

--- a/src/Phpforce/SoapClient/Client.php
+++ b/src/Phpforce/SoapClient/Client.php
@@ -665,7 +665,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
 
         foreach (get_object_vars($object) as $field => $value) {
             $type = $this->soapClient->getSoapElementType($objectType, $field);
-            if (!$type) {
+            if ($field != 'Id' && !$type) {
                 continue;
             }
 

--- a/src/Phpforce/SoapClient/ClientBuilder.php
+++ b/src/Phpforce/SoapClient/ClientBuilder.php
@@ -17,17 +17,19 @@ class ClientBuilder
     /**
      * Construct client builder with required parameters
      *
-     * @param string $wsdl     Path to your Salesforce WSDL
-     * @param string $username Your Salesforce username
-     * @param string $password Your Salesforce password
-     * @param string $token    Your Salesforce security token
+     * @param string $wsdl        Path to your Salesforce WSDL
+     * @param string $username    Your Salesforce username
+     * @param string $password    Your Salesforce password
+     * @param string $token       Your Salesforce security token
+     * @param array  $soapOptions Further options to be passed to the SoapClient
      */
-    public function __construct($wsdl, $username, $password, $token)
+    public function __construct($wsdl, $username, $password, $token, array $soapOptions = array())
     {
         $this->wsdl = $wsdl;
         $this->username = $username;
         $this->password = $password;
         $this->token = $token;
+        $this->soapOptions = $soapOptions;
     }
 
     /**
@@ -52,7 +54,7 @@ class ClientBuilder
     public function build()
     {
         $soapClientFactory = new SoapClientFactory();
-        $soapClient = $soapClientFactory->factory($this->wsdl);
+        $soapClient = $soapClientFactory->factory($this->wsdl, $this->soapOptions);
 
         $client = new Client($soapClient, $this->username, $this->password, $this->token);
 
@@ -64,4 +66,3 @@ class ClientBuilder
         return $client;
     }
 }
-

--- a/src/Phpforce/SoapClient/Soap/SoapClientFactory.php
+++ b/src/Phpforce/SoapClient/Soap/SoapClientFactory.php
@@ -52,19 +52,23 @@ class SoapClientFactory
     protected $typeConverters;
 
     /**
-     * @param string $wsdl Some argument description
-     *
+     * @param string $wsdl Path to WSDL file
+     * @param array $soapOptions
      * @return SoapClient
      */
-    public function factory($wsdl)
+    public function factory($wsdl, array $soapOptions = array())
     {
-        return new SoapClient($wsdl, array(
-            'trace'     => 1,
-            'features'  => \SOAP_SINGLE_ELEMENT_ARRAYS,
-            'classmap'  => $this->classmap,
-            'typemap'   => $this->getTypeConverters()->getTypemap(),
+        $defaults = array(
+            'trace'      => 1,
+            'features'   => \SOAP_SINGLE_ELEMENT_ARRAYS,
+            'classmap'   => $this->classmap,
+            'typemap'    => $this->getTypeConverters()->getTypemap(),
             'cache_wsdl' => \WSDL_CACHE_MEMORY
-        ));
+        );
+
+        $options = array_merge($defaults, $soapOptions);
+
+        return new SoapClient($wsdl, $options);
     }
 
     /**


### PR DESCRIPTION
We needed this to be able to pass in proxy_host and proxy_port, but it could be used for other options. Also includes a couple of typo fixes to the code snippets in README.md.
