### PR TITLE
Fix for Update not sending ID

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpforce/soap-client",
+    "name": "jahumes/soap-client",
     "type": "library",
     "description": "A PHP client for the Salesforce SOAP API",
     "keywords": [ "salesforce", "crm", "soap", "force.com", "web services" ],

--- a/src/Phpforce/SoapClient/Soap/SoapClient.php
+++ b/src/Phpforce/SoapClient/Soap/SoapClient.php
@@ -64,7 +64,6 @@ class SoapClient extends \SoapClient
     public function getSoapElements($complexType)
     {
         $types = $this->getSoapTypes();
-        $types['Id'] = 'string';
         if (isset($types[$complexType])) {
             return $types[$complexType];
         }
@@ -81,6 +80,7 @@ class SoapClient extends \SoapClient
     public function getSoapElementType($complexType, $element)
     {
         $elements = $this->getSoapElements($complexType);
+        $elements['Id'] = 'string';
         if ($elements && isset($elements[$element])) {
             return $elements[$element];
         }

--- a/src/Phpforce/SoapClient/Soap/SoapClient.php
+++ b/src/Phpforce/SoapClient/Soap/SoapClient.php
@@ -64,6 +64,7 @@ class SoapClient extends \SoapClient
     public function getSoapElements($complexType)
     {
         $types = $this->getSoapTypes();
+        $types['Id'] = 'string';
         if (isset($types[$complexType])) {
             return $types[$complexType];
         }


### PR DESCRIPTION
As we were using the SOAP client to update Accounts, none of the updates were going through because the system wasn't sending the Id along (we are sending an array on objects). The issue seems to stem from the code that validates the types of the attributes that can be updated and sent back. Since Id is not an editable field, it is not returned with all the other custom fields in Salesforce. I had to add one line of code to fix this.

````$elements['Id'] = 'string';````

This was added to the SoapClient class in the getSoapElementType function.