### PR TITLE
Fix: Issues upserting by ID and specifying nillable fields

### DIFF
--- a/src/Phpforce/SoapClient/Soap/SoapClient.php
+++ b/src/Phpforce/SoapClient/Soap/SoapClient.php
@@ -40,6 +40,12 @@ class SoapClient extends \SoapClient
                     preg_match('/\s* (.*) (.*);/', $line, $matches);
                     $properties[$matches[2]] = $matches[1];
                 }
+
+                // Since every object extends sObject, need to append sObject elements to all native and custom objects
+                if ($typeName !== 'sObject' && array_key_exists('sObject', $this->types)) {
+                    $properties = array_merge($properties, $this->types['sObject']);
+                }
+
                 $this->types[$typeName] = $properties;
             }
         }


### PR DESCRIPTION
Since every object extends sObject, need to append sObject elements to all native and custom objects
