### PR TITLE
Fix connection to my-domain sandboxes

### DIFF
--- a/src/Phpforce/SoapClient/Result/LoginResult.php
+++ b/src/Phpforce/SoapClient/Result/LoginResult.php
@@ -83,7 +83,7 @@ class LoginResult
         }
 
         $match = preg_match(
-            '/https:\/\/(?<instance>[^-]+)\.salesforce\.com/',
+            '/https:\/\/(?<instance>.+)\.salesforce\.com/',
             $this->serverUrl,
             $matches
         );


### PR DESCRIPTION
The server url on sandboxes contains dashes, which makes the process to
fail by not getting the full url.

The server url
https://digitaldeer--com.cs1.my.salesforce.com/services/Soap/c/33.0/xxxxxxxxxxxxxxx
should return an instance of digitaldeer--com.cs1.my