### PR TITLE
Made $soapClient property public

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "phpforce/soap-client",
+    "name": "winternet-studio/salesforce-soap-client",
     "type": "library",
     "description": "A PHP client for the Salesforce SOAP API",
     "keywords": [ "salesforce", "crm", "soap", "force.com", "web services" ],
@@ -25,7 +25,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Phpforce\\SoapClient": "src"
+            "winternet\\SalesforceSoapClient": "src"
         }
     }
 }

--- a/src/Phpforce/SoapClient/Client.php
+++ b/src/Phpforce/SoapClient/Client.php
@@ -33,7 +33,7 @@ class Client extends AbstractHasDispatcher implements ClientInterface
      *
      * @var SoapClient
      */
-    protected $soapClient;
+    public $soapClient;
 
     /**
      * @var string


### PR DESCRIPTION
Made property public so that we can access it and call methods like __getLastRequest(), __getLastRequestHeaders(), __getLastResponse() and __getLastResponseHeaders()

I couldn't do what I needed to with this library without making this change.